### PR TITLE
Fix light theme text contrast

### DIFF
--- a/site.js
+++ b/site.js
@@ -14,12 +14,13 @@
     }
 
     function setTheme(theme) {
-        document.body.setAttribute('data-theme', theme);
+        document.documentElement.setAttribute('data-theme', theme);
         updateSubstack(theme);
     }
 
     window.toggleTheme = function () {
-        const next = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        const current = document.documentElement.getAttribute('data-theme') || 'dark';
+        const next = current === 'dark' ? 'light' : 'dark';
         setTheme(next);
         localStorage.setItem('theme', next);
     };

--- a/style.css
+++ b/style.css
@@ -16,9 +16,13 @@
     --label-track: 0.12em;
 }
 
-[data-theme="light"] {
+html[data-theme="light"] {
     --bg: #f5f1f1;
     --text: #0e0e0e;
+    --line: color-mix(in srgb, var(--text) 12%, transparent);
+    --text-muted: color-mix(in srgb, var(--text) 55%, transparent);
+    --text-dim: color-mix(in srgb, var(--text) 42%, transparent);
+    --accent-muted: color-mix(in srgb, var(--accent) 75%, transparent);
 }
 
 /* ── Reset & base ── */
@@ -350,8 +354,8 @@ nav {
 
 .theme-toggle::after { content: "☾"; }
 .theme-toggle:hover::after { content: "✺"; }
-[data-theme="light"] .theme-toggle::after { content: "✺"; }
-[data-theme="light"] .theme-toggle:hover::after { content: "☾"; }
+html[data-theme="light"] .theme-toggle::after { content: "✺"; }
+html[data-theme="light"] .theme-toggle:hover::after { content: "☾"; }
 
 /* ── Page header (hero + inner pages) ── */
 header { position: relative; padding: var(--space) 0; }


### PR DESCRIPTION
## Summary
- Recompute `--text-muted`, `--text-dim`, `--line`, and `--accent-muted` under `html[data-theme="light"]` so secondary text is readable on the light background.
- Apply `data-theme` on `documentElement` instead of `body` so tokens resolve correctly.

## Test plan
- [ ] Toggle light mode on the homepage and confirm nav links, eyebrow, hero quote, and scroll hint are visible
- [ ] Verify dark mode still looks correct
- [ ] Spot-check testimonials and archive pages in both themes

Made with [Cursor](https://cursor.com)