### PR TITLE
Unify site footer layout across all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -33,16 +33,15 @@
 
         <footer class="site-footer">
             <div class="footer-left">
-                <h2 class="footer-heading">Reach out</h2>
-            </div>
-            <div class="footer-right">
                 <div class="footer-links">
                     <a href="mailto:moni@inner.foundation">Email</a>
                     <a href="https://status.app/u/G1sAAATCbSWL0ZAumSxZMFptwo_xwT1snwQnHLA3kDgNNCA7ysFDNqUIZ6pLXjmde03L7J_ra0ooc_R6gv0zzMSBa2OzbPm5CTFXGEc8qLQW8QA=#zQ3shsxV5ExQQkoUL7Vsq6uasTozTfnCYV6d4raFNcduzUEwN">Status</a>
                     <a href="https://t.me/monicazng">Telegram</a>
                     <a href="https://x.com/monicazng">X</a>
                 </div>
-                <span class="footer-copy">© 2026 All rights reserved.</span>
+            </div>
+            <div class="footer-right">
+                <span class="footer-copy">© 2026 All rights reserved</span>
             </div>
         </footer>
     </div>

--- a/archivo.html
+++ b/archivo.html
@@ -118,16 +118,15 @@
 
         <footer class="site-footer">
             <div class="footer-left">
-                <h2 class="footer-heading">Reach out</h2>
-            </div>
-            <div class="footer-right">
                 <div class="footer-links">
                     <a href="mailto:moni@inner.foundation">Email</a>
                     <a href="https://status.app/u/G1sAAATCbSWL0ZAumSxZMFptwo_xwT1snwQnHLA3kDgNNCA7ysFDNqUIZ6pLXjmde03L7J_ra0ooc_R6gv0zzMSBa2OzbPm5CTFXGEc8qLQW8QA=#zQ3shsxV5ExQQkoUL7Vsq6uasTozTfnCYV6d4raFNcduzUEwN">Status</a>
                     <a href="https://t.me/monicazng">Telegram</a>
                     <a href="https://x.com/monicazng">X</a>
                 </div>
-                <span class="footer-copy">© 2026 All rights reserved.</span>
+            </div>
+            <div class="footer-right">
+                <span class="footer-copy">© 2026 All rights reserved</span>
             </div>
         </footer>
     </div>

--- a/archivo/integridad.html
+++ b/archivo/integridad.html
@@ -222,14 +222,16 @@
         </main>
 
         <footer class="site-footer">
-            <div class="footer-right">
+            <div class="footer-left">
                 <div class="footer-links">
                     <a href="mailto:moni@inner.foundation">Email</a>
                     <a href="https://status.app/u/G1sAAATCbSWL0ZAumSxZMFptwo_xwT1snwQnHLA3kDgNNCA7ysFDNqUIZ6pLXjmde03L7J_ra0ooc_R6gv0zzMSBa2OzbPm5CTFXGEc8qLQW8QA=#zQ3shsxV5ExQQkoUL7Vsq6uasTozTfnCYV6d4raFNcduzUEwN">Status</a>
                     <a href="https://t.me/monicazng">Telegram</a>
                     <a href="https://x.com/monicazng">X</a>
                 </div>
-                <span class="footer-copy">© 2026 All rights reserved.</span>
+            </div>
+            <div class="footer-right">
+                <span class="footer-copy">© 2026 All rights reserved</span>
             </div>
         </footer>
     </div>

--- a/archivo/voces.html
+++ b/archivo/voces.html
@@ -192,16 +192,15 @@
 
         <footer class="site-footer">
             <div class="footer-left">
-                <h2 class="footer-heading">Reach out</h2>
-            </div>
-            <div class="footer-right">
                 <div class="footer-links">
                     <a href="mailto:moni@inner.foundation">Email</a>
                     <a href="https://status.app/u/G1sAAATCbSWL0ZAumSxZMFptwo_xwT1snwQnHLA3kDgNNCA7ysFDNqUIZ6pLXjmde03L7J_ra0ooc_R6gv0zzMSBa2OzbPm5CTFXGEc8qLQW8QA=#zQ3shsxV5ExQQkoUL7Vsq6uasTozTfnCYV6d4raFNcduzUEwN">Status</a>
                     <a href="https://t.me/monicazng">Telegram</a>
                     <a href="https://x.com/monicazng">X</a>
                 </div>
-                <span class="footer-copy">© 2026 All rights reserved.</span>
+            </div>
+            <div class="footer-right">
+                <span class="footer-copy">© 2026 All rights reserved</span>
             </div>
         </footer>
     </div>

--- a/manifesto.html
+++ b/manifesto.html
@@ -111,16 +111,15 @@
 
         <footer class="site-footer">
             <div class="footer-left">
-                <h2 class="footer-heading">Reach out</h2>
-            </div>
-            <div class="footer-right">
                 <div class="footer-links">
                     <a href="mailto:moni@inner.foundation">Email</a>
                     <a href="https://status.app/u/G1sAAATCbSWL0ZAumSxZMFptwo_xwT1snwQnHLA3kDgNNCA7ysFDNqUIZ6pLXjmde03L7J_ra0ooc_R6gv0zzMSBa2OzbPm5CTFXGEc8qLQW8QA=#zQ3shsxV5ExQQkoUL7Vsq6uasTozTfnCYV6d4raFNcduzUEwN">Status</a>
                     <a href="https://t.me/monicazng">Telegram</a>
                     <a href="https://x.com/monicazng">X</a>
                 </div>
-                <span class="footer-copy">© 2026 All rights reserved.</span>
+            </div>
+            <div class="footer-right">
+                <span class="footer-copy">© 2026 All rights reserved</span>
             </div>
         </footer>
     </div>

--- a/testimonials.html
+++ b/testimonials.html
@@ -163,16 +163,15 @@
 
         <footer class="site-footer">
             <div class="footer-left">
-                <h2 class="footer-heading">Reach out</h2>
-            </div>
-            <div class="footer-right">
                 <div class="footer-links">
                     <a href="mailto:moni@inner.foundation">Email</a>
                     <a href="https://status.app/u/G1sAAATCbSWL0ZAumSxZMFptwo_xwT1snwQnHLA3kDgNNCA7ysFDNqUIZ6pLXjmde03L7J_ra0ooc_R6gv0zzMSBa2OzbPm5CTFXGEc8qLQW8QA=#zQ3shsxV5ExQQkoUL7Vsq6uasTozTfnCYV6d4raFNcduzUEwN">Status</a>
                     <a href="https://t.me/monicazng">Telegram</a>
                     <a href="https://x.com/monicazng">X</a>
                 </div>
-                <span class="footer-copy">© 2026 All rights reserved.</span>
+            </div>
+            <div class="footer-right">
+                <span class="footer-copy">© 2026 All rights reserved</span>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
Align every page footer with the home page: links on the left, copyright on the right, without the Reach out heading.